### PR TITLE
JSON-RPCでtickerを取得する

### DIFF
--- a/controllers/streaming.go
+++ b/controllers/streaming.go
@@ -1,19 +1,14 @@
 package controllers
 
 import (
-	"encoding/json"
-	"time"
-
 	"github.com/cryptocurrency-trading-bot/models"
-	"github.com/cryptocurrency-trading-bot/utils"
 )
 
 func Streaming() {
-	for {
-		resp, _ := utils.DoHttpRequest("GET", "https://api.bitflyer.com/v1/ticker", nil, nil, nil)
-		var ticker models.Ticker
-		json.Unmarshal(resp, &ticker)
+	tickerChannel := make(chan models.Ticker)
+	go models.GetRealTimeTicker(tickerChannel)
+
+	for ticker := range tickerChannel {
 		models.CreateCandle(&ticker)
-		time.Sleep(time.Second)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	gorm.io/driver/mysql v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=


### PR DESCRIPTION
## やったこと
tickerの取得をHTTPリクエストを繰り返し送るやり方から、WebSocketとJSON-RPCを使うやり方に変更した

## 参考
- [WebSocketとJSON-RPCでリアルタイムAPIデータ取得【Go】 - 技術向上](https://tech-up.hatenablog.com/entry/2018/12/09/200134)
- [Goでmapをjson文字列に変換する - Qiita](https://qiita.com/konchanxxx/items/dce130f79c49e04e9931)